### PR TITLE
style: clean up api

### DIFF
--- a/uart8250/src/lib.rs
+++ b/uart8250/src/lib.rs
@@ -8,7 +8,7 @@ This crate provides a struct with many methods to operate an 8250 UART.
 
 #![no_std]
 
-pub mod registers;
+mod registers;
 mod uart;
 
-pub use uart::{ChipFifoInfo, InterruptType, MmioUart8250, Parity, IER, LSR, MSR};
+pub use uart::{ChipFifoInfo, InterruptType, MmioUart8250, Parity};

--- a/uart8250/src/registers.rs
+++ b/uart8250/src/registers.rs
@@ -36,7 +36,7 @@ pub struct Registers {
 
 impl Registers {
     /// Constructs a new instance of the UART registers starting at the given base address.
-    pub fn from_base_address(base_address: usize) -> &'static mut Self {
-        unsafe { &mut *(base_address as *mut crate::registers::Registers) }
+    pub unsafe fn from_base_address(base_address: usize) -> &'static mut Self {
+        &mut *(base_address as *mut crate::registers::Registers)
     }
 }

--- a/uart8250/src/uart.rs
+++ b/uart8250/src/uart.rs
@@ -102,7 +102,13 @@ pub struct MmioUart8250<'a> {
 
 impl<'a> MmioUart8250<'a> {
     /// Creates a new UART.
-    pub fn new(base_address: usize) -> Self {
+    ///
+    /// # Safety
+    ///
+    /// The given base address must point to the 8 MMIO control registers of an appropriate UART
+    /// device, which must be mapped into the address space of the process as device memory and not
+    /// have any other aliases.
+    pub unsafe fn new(base_address: usize) -> Self {
         Self {
             reg: Registers::from_base_address(base_address),
         }
@@ -128,7 +134,13 @@ impl<'a> MmioUart8250<'a> {
     }
 
     /// Sets a new base address for the UART.
-    pub fn set_base_address(&mut self, base_address: usize) {
+    ///
+    /// # Safety
+    ///
+    /// The given base address must point to the 8 MMIO control registers of an appropriate UART
+    /// device, which must be mapped into the address space of the process as device memory and not
+    /// have any other aliases.
+    pub unsafe fn set_base_address(&mut self, base_address: usize) {
         self.reg = Registers::from_base_address(base_address);
     }
 
@@ -781,7 +793,7 @@ mod tests {
         // Create a fake UART using an in-memory buffer, and check that it is initialised as
         // expected.
         let mut fake_registers: [u8; 8] = [0xff; 8];
-        let uart = MmioUart8250::new(&mut fake_registers as *mut u8 as usize);
+        let uart = unsafe { MmioUart8250::new(&mut fake_registers as *mut u8 as usize) };
 
         uart.init(11_059_200, 115200);
 
@@ -794,7 +806,7 @@ mod tests {
     #[test]
     fn write() {
         let mut fake_registers: [u8; 8] = [0; 8];
-        let uart = MmioUart8250::new(&mut fake_registers as *mut u8 as usize);
+        let uart = unsafe { MmioUart8250::new(&mut fake_registers as *mut u8 as usize) };
 
         uart.write_byte(0x42);
 
@@ -804,7 +816,7 @@ mod tests {
     #[test]
     fn read() {
         let mut fake_registers: [u8; 8] = [0; 8];
-        let uart = MmioUart8250::new(&mut fake_registers as *mut u8 as usize);
+        let uart = unsafe { MmioUart8250::new(&mut fake_registers as *mut u8 as usize) };
 
         // First try to read when there is nothing available.
         assert_eq!(uart.read_byte(), None);

--- a/uart8250/src/uart.rs
+++ b/uart8250/src/uart.rs
@@ -331,11 +331,6 @@ impl<'a> MmioUart8250<'a> {
         self.ier().contains(IER::LPM)
     }
 
-    /// toggle low power mode (16750) (IER\[5\])
-    pub fn toggle_low_power_mode(&self) {
-        self.set_ier(self.ier() ^ IER::LPM)
-    }
-
     /// enable low power mode (16750) (IER\[5\])
     pub fn enable_low_power_mode(&self) {
         self.set_ier(self.ier() | IER::LPM)
@@ -349,11 +344,6 @@ impl<'a> MmioUart8250<'a> {
     /// get whether sleep mode (16750) is enabled (IER\[4\])
     pub fn is_sleep_mode_enabled(&self) -> bool {
         self.ier().contains(IER::SM)
-    }
-
-    /// toggle sleep mode (16750) (IER\[4\])
-    pub fn toggle_sleep_mode(&self) {
-        self.set_ier(self.ier() ^ IER::SM)
     }
 
     /// enable sleep mode (16750) (IER\[4\])
@@ -371,11 +361,6 @@ impl<'a> MmioUart8250<'a> {
         self.ier().contains(IER::MSI)
     }
 
-    /// toggle modem status interrupt (IER\[3\])
-    pub fn toggle_modem_status_interrupt(&self) {
-        self.set_ier(self.ier() ^ IER::MSI)
-    }
-
     /// enable modem status interrupt (IER\[3\])
     pub fn enable_modem_status_interrupt(&self) {
         self.set_ier(self.ier() | IER::MSI)
@@ -389,11 +374,6 @@ impl<'a> MmioUart8250<'a> {
     /// get whether receiver line status interrupt is enabled (IER\[2\])
     pub fn is_receiver_line_status_interrupt_enabled(&self) -> bool {
         self.ier().contains(IER::RLSI)
-    }
-
-    /// toggle receiver line status interrupt (IER\[2\])
-    pub fn toggle_receiver_line_status_interrupt(&self) {
-        self.set_ier(self.ier() ^ IER::RLSI)
     }
 
     /// enable receiver line status interrupt (IER\[2\])
@@ -411,11 +391,6 @@ impl<'a> MmioUart8250<'a> {
         self.ier().contains(IER::THREI)
     }
 
-    /// toggle transmitter holding register empty interrupt (IER\[1\])
-    pub fn toggle_transmitter_holding_register_empty_interrupt(&self) {
-        self.set_ier(self.ier() ^ IER::THREI)
-    }
-
     /// enable transmitter holding register empty interrupt (IER\[1\])
     pub fn enable_transmitter_holding_register_empty_interrupt(&self) {
         self.set_ier(self.ier() | IER::THREI)
@@ -429,11 +404,6 @@ impl<'a> MmioUart8250<'a> {
     /// get whether received data available is enabled (IER\[0\])
     pub fn is_received_data_available_interrupt_enabled(&self) -> bool {
         self.ier().contains(IER::RDAI)
-    }
-
-    /// toggle received data available (IER\[0\])
-    pub fn toggle_received_data_available_interrupt(&self) {
-        self.set_ier(self.ier() ^ IER::RDAI)
     }
 
     /// enable received data available (IER\[0\])

--- a/uart8250/src/uart.rs
+++ b/uart8250/src/uart.rs
@@ -560,18 +560,13 @@ impl<'a> MmioUart8250<'a> {
         unsafe { self.reg.lcr.write(value) }
     }
 
-    /// get whether DLAB is enabled
-    pub fn is_divisor_latch_accessible(&self) -> bool {
-        self.reg.lcr.read() & 0b1000_0000 != 0
-    }
-
     /// enable DLAB
-    pub fn enable_divisor_latch_accessible(&self) {
+    fn enable_divisor_latch_accessible(&self) {
         unsafe { self.reg.lcr.modify(|v| v | 0b1000_0000) }
     }
 
     /// disable DLAB
-    pub fn disable_divisor_latch_accessible(&self) {
+    fn disable_divisor_latch_accessible(&self) {
         unsafe { self.reg.lcr.modify(|v| v & !0b1000_0000) }
     }
 
@@ -800,7 +795,6 @@ mod tests {
         assert!(matches!(uart.get_parity(), Parity::No));
         assert_eq!(uart.get_stop_bit(), 1);
         assert_eq!(uart.get_word_length(), 8);
-        assert_eq!(uart.is_divisor_latch_accessible(), false);
     }
 
     #[test]


### PR DESCRIPTION
This makes a number of changes to the API of `MmioUart8250`, in particular:

1. I've removed a bunch of methods for raw register access from the public interface.  If clients need functionality not provided by the wrapper methods then that functionality should be added to this crate, rather than having clients directly access registers.
2. I removed the `toggle_` methods. I don't think these were very useful, I can't see any case where a client of the library would want to toggle the state of some setting without knowing what state it expects it to end up in, in which case it can just use the `enable_` or `disable_` method.
3. I've marked MmioUart8250::new as unsafe. The caller needs to make sure that the address being passed in really is the base address of appropriate MMIO registers, and not an unmapped address, or the address of some other memory. Otherwise it would let safe code read and write arbitrary memory, which is unsound.

I also added some tests.