### PR TITLE
Support 32-bit register mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "embedded-hal"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,7 +43,7 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 name = "uart8250"
 version = "0.6.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "embedded-hal",
  "nb 1.0.0",
  "volatile-register",
@@ -47,7 +53,7 @@ dependencies = [
 name = "uart_xilinx"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "volatile-register",
 ]
 

--- a/uart8250/Cargo.toml
+++ b/uart8250/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "1"
+bitflags = "2"
 embedded-hal = { version = "0.2.7", optional = true }
 nb = { version = "1.0.0", optional = true }
 volatile-register = "0.2"

--- a/uart8250/README.md
+++ b/uart8250/README.md
@@ -13,7 +13,7 @@ Besides, this crate currently is not following [Rust API Guidelines](https://rus
 ## Usage
 
 ```rust
-let uart = MmioUart8250::new(0x1000_0000);
+let uart = MmioUart8250::<u8>::new(0x1000_0000);
 uart.init(11_059_200, 115200);
 if let Some(c) = uart.read_byte() {
     //...
@@ -23,7 +23,7 @@ if let Some(c) = uart.read_byte() {
 If you turn on feature `fmt`
 
 ```rust
-let uart = MmioUart8250::new(0x1000_0000);
+let uart = MmioUart8250::<u8>::new(0x1000_0000);
 uart.init(11_059_200, 115200);
 
 pub fn print_uart(args: fmt::Arguments) {

--- a/uart8250/src/registers.rs
+++ b/uart8250/src/registers.rs
@@ -23,61 +23,82 @@ use volatile_register::{RO, RW};
 /// | +6           | x    | Read       | MSR    | Modem Status Register             |
 /// | +7           | x    | Read/Write | SR     | Scratch Register                  |
 #[repr(C)]
-pub struct Registers<const W: usize> {
-    pub thr_rbr_dll: RwReg<W, u8>,
-    pub ier_dlh: RwReg<W, u8>,
-    pub iir_fcr: RwReg<W, u8>,
-    pub lcr: RwReg<W, u8>,
-    pub mcr: RwReg<W, u8>,
-    pub lsr: RoReg<W, u8>,
-    pub msr: RoReg<W, u8>,
-    pub scratch: RwReg<W, u8>,
+pub struct Registers<R: Register + Copy> {
+    pub thr_rbr_dll: RwReg<R>,
+    pub ier_dlh: RwReg<R>,
+    pub iir_fcr: RwReg<R>,
+    pub lcr: RwReg<R>,
+    pub mcr: RwReg<R>,
+    pub lsr: RoReg<R>,
+    pub msr: RoReg<R>,
+    pub scratch: RwReg<R>,
 }
 
 #[repr(C)]
-pub struct RoReg<const W: usize, T: Copy>([RO<T>; W]);
+pub struct RoReg<R: Register + Copy>(RO<R>);
 
-impl<const W: usize, T: Copy> RoReg<W, T> {
+impl<R: Register + Copy> RoReg<R> {
     /// Reads the value of the register
     #[inline(always)]
-    pub fn read(&self) -> T {
-        self.0[0].read()
+    pub fn read(&self) -> u8 {
+        self.0.read().val()
     }
 }
 
 #[repr(C)]
-pub struct RwReg<const W: usize, T: Copy>([RW<T>; W]);
+pub struct RwReg<R: Register + Copy>(RW<R>);
 
-impl<const W: usize, T: Copy> RwReg<W, T> {
+impl<R: Register + Copy> RwReg<R> {
     /// Performs a read-modify-write operation
     ///
     /// NOTE: `unsafe` because writes to a register are side effectful
     #[inline(always)]
     pub unsafe fn modify<F>(&self, f: F)
     where
-        F: FnOnce(T) -> T,
+        F: FnOnce(u8) -> u8,
     {
-        self.0[0].modify(f);
+        self.0.write(f(self.read()).into());
     }
 
     /// Reads the value of the register
     #[inline(always)]
-    pub fn read(&self) -> T {
-        self.0[0].read()
+    pub fn read(&self) -> u8 {
+        self.0.read().val()
     }
 
     /// Writes a `value` into the register
     ///
     /// NOTE: `unsafe` because writes to a register are side effectful
     #[inline(always)]
-    pub unsafe fn write(&self, value: T) {
-        self.0[0].write(value);
+    pub unsafe fn write(&self, value: u8) {
+        self.0.write(value.into())
     }
 }
 
-impl<const W: usize> Registers<W> {
+impl<R: Register + Copy> Registers<R> {
     /// Constructs a new instance of the UART registers starting at the given base address.
     pub unsafe fn from_base_address(base_address: usize) -> &'static mut Self {
-        &mut *(base_address as *mut Registers<W>)
+        &mut *(base_address as *mut Registers<R>)
+    }
+}
+
+pub trait Register: From<u8> {
+    /// 取出寄存器中的有效位。
+    fn val(self) -> u8;
+}
+
+/// 寄存器的 8 位模式。
+impl Register for u8 {
+    #[inline]
+    fn val(self) -> u8 {
+        self
+    }
+}
+
+/// 寄存器的 32 位模式。
+impl Register for u32 {
+    #[inline]
+    fn val(self) -> u8 {
+        self as _
     }
 }

--- a/uart8250/src/uart.rs
+++ b/uart8250/src/uart.rs
@@ -3,7 +3,7 @@ use bitflags::bitflags;
 use core::convert::Infallible;
 use core::fmt::{self, Display, Formatter};
 
-use crate::registers::Registers;
+use crate::registers::{Register, Registers};
 
 bitflags! {
     /// Interrupt Enable Register (bitflags)
@@ -112,11 +112,11 @@ impl Display for TransmitError {
 /// # MMIO version of an 8250 UART.
 ///
 /// **Note** This is only tested on the NS16550 compatible UART used in QEMU 5.0 virt machine of RISC-V.
-pub struct MmioUart8250<'a, const W: usize> {
-    reg: &'a mut Registers<W>,
+pub struct MmioUart8250<'a, R: Register + Copy> {
+    reg: &'a mut Registers<R>,
 }
 
-impl<'a, const W: usize> MmioUart8250<'a, W> {
+impl<'a, R: Register + Copy + 'static> MmioUart8250<'a, R> {
     /// Creates a new UART.
     ///
     /// # Safety
@@ -670,7 +670,7 @@ impl<'a, const W: usize> MmioUart8250<'a, W> {
 ///
 /// A simple implementation, may be changed in the future
 #[cfg(feature = "fmt")]
-impl<'a, const W: usize> fmt::Write for MmioUart8250<'a, W> {
+impl<'a, R: Register + Copy + 'static> fmt::Write for MmioUart8250<'a, R> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for c in s.as_bytes() {
             // If buffer is full, keep retrying.
@@ -681,7 +681,7 @@ impl<'a, const W: usize> fmt::Write for MmioUart8250<'a, W> {
 }
 
 #[cfg(feature = "embedded")]
-impl<const W: usize> embedded_hal::serial::Read<u8> for MmioUart8250<'_, W> {
+impl<R: Register + Copy + 'static> embedded_hal::serial::Read<u8> for MmioUart8250<'_, R> {
     type Error = Infallible;
 
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
@@ -690,7 +690,7 @@ impl<const W: usize> embedded_hal::serial::Read<u8> for MmioUart8250<'_, W> {
 }
 
 #[cfg(feature = "embedded")]
-impl<const W: usize> embedded_hal::serial::Write<u8> for MmioUart8250<'_, W> {
+impl<R: Register + Copy + 'static> embedded_hal::serial::Write<u8> for MmioUart8250<'_, R> {
     type Error = Infallible;
 
     fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
@@ -720,7 +720,7 @@ mod tests {
         // Create a fake UART using an in-memory buffer, and check that it is initialised as
         // expected.
         let mut fake_registers: [u8; 8] = [0xff; 8];
-        let uart = unsafe { MmioUart8250::<1>::new(&mut fake_registers as *mut u8 as usize) };
+        let uart = unsafe { MmioUart8250::<u8>::new(&mut fake_registers as *mut u8 as usize) };
 
         uart.init(11_059_200, 115200);
 
@@ -732,7 +732,7 @@ mod tests {
     #[test]
     fn write() {
         let mut fake_registers: [u8; 8] = [0; 8];
-        let uart = unsafe { MmioUart8250::<1>::new(&mut fake_registers as *mut u8 as usize) };
+        let uart = unsafe { MmioUart8250::<u8>::new(&mut fake_registers as *mut u8 as usize) };
 
         // Pretend that the transmit buffer is full.
         fake_registers[5] = 0;
@@ -748,7 +748,7 @@ mod tests {
     #[test]
     fn read() {
         let mut fake_registers: [u8; 8] = [0; 8];
-        let uart = unsafe { MmioUart8250::<1>::new(&mut fake_registers as *mut u8 as usize) };
+        let uart = unsafe { MmioUart8250::<u8>::new(&mut fake_registers as *mut u8 as usize) };
 
         // First try to read when there is nothing available.
         assert_eq!(uart.read_byte(), None);


### PR DESCRIPTION
The register width of some uart8250 implementations is 32bit ([visionfive2 board](https://www.starfivetech.com/en/site/boards)), but the effective bits are only the lower 8 bits, so I modified the relevant definitions so that this library can support these two modes.