### PR TITLE
feat(uart_xilinx): Remove lifetime & add read write function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,15 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "embedded-hal"
@@ -24,22 +30,22 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
 dependencies = [
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
 name = "nb"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "uart8250"
 version = "0.6.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "embedded-hal",
- "nb 1.0.0",
+ "nb 1.1.0",
  "volatile-register",
 ]
 
@@ -47,7 +53,7 @@ dependencies = [
 name = "uart_xilinx"
 version = "0.2.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "volatile-register",
 ]
 
@@ -65,9 +71,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "volatile-register"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
+checksum = "de437e2a6208b014ab52972a27e59b33fa2920d3e00fe05026167a1c509d19cc"
 dependencies = [
  "vcell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "uart_xilinx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitflags",
  "volatile-register",

--- a/uart_xilinx/Cargo.toml
+++ b/uart_xilinx/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 [dependencies]
 # embedded-hal = { version = "=1.0.0-alpha.4", optional = true }
 # nb = { version = "1", optional = true }
-bitflags = "1"
+bitflags = "2"
 volatile-register = "0.2"
 
 [features]

--- a/uart_xilinx/src/uart_lite/registers.rs
+++ b/uart_xilinx/src/uart_lite/registers.rs
@@ -1,11 +1,5 @@
 use volatile_register::{RO, WO};
 
-macro_rules! cast {
-    ($expr:expr) => {
-        unsafe { &mut *(($expr) as *mut super::registers::Registers) }
-    };
-}
-
 /// # UART Registers
 #[repr(C)]
 pub struct Registers {

--- a/uart_xilinx/src/uart_lite/uart.rs
+++ b/uart_xilinx/src/uart_lite/uart.rs
@@ -165,7 +165,7 @@ impl MmioUartXpsLite {
 ///
 /// A simple implementation, may be changed in the future
 #[cfg(feature = "fmt")]
-impl<'a> fmt::Write for MmioUartXpsLite<'a> {
+impl fmt::Write for MmioUartXpsLite {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for c in s.as_bytes() {
             self.write_byte(*c);
@@ -340,7 +340,7 @@ impl MmioUartAxiLite {
 ///
 /// A simple implementation, may be changed in the future
 #[cfg(feature = "fmt")]
-impl<'a> fmt::Write for MmioUartAxiLite<'a> {
+impl fmt::Write for MmioUartAxiLite {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for c in s.as_bytes() {
             self.write_byte(*c);

--- a/uart_xilinx/src/uart_lite/uart.rs
+++ b/uart_xilinx/src/uart_lite/uart.rs
@@ -1,7 +1,6 @@
+use super::registers::Registers;
 #[cfg(feature = "fmt")]
 use core::fmt;
-
-use super::registers::Registers;
 
 bitflags! {
     /// Status Register Bit Definitions
@@ -41,7 +40,8 @@ impl MmioUartXpsLite {
         }
     }
 
-    pub fn reg(&self) -> &mut Registers {
+    #[allow(clippy::mut_from_ref)]
+    fn reg(&self) -> &mut Registers {
         unsafe { &mut *self.reg_pointer }
     }
 
@@ -189,7 +189,8 @@ impl MmioUartAxiLite {
         }
     }
 
-    pub fn reg(&self) -> &mut Registers {
+    #[allow(clippy::mut_from_ref)]
+    fn reg(&self) -> &mut Registers {
         unsafe { &mut *self.reg_pointer }
     }
 

--- a/uart_xilinx/src/uart_lite/uart.rs
+++ b/uart_xilinx/src/uart_lite/uart.rs
@@ -29,21 +29,25 @@ bitflags! {
 /// # MMIO version of XPS UART Lite
 ///
 /// **Noticed** This hasn't been tested.
-pub struct MmioUartXpsLite<'a> {
-    reg: &'a mut Registers,
+pub struct MmioUartXpsLite {
+    reg_pointer: *mut Registers,
 }
 
-impl<'a> MmioUartXpsLite<'a> {
+impl MmioUartXpsLite {
     /// New a uart
-    pub fn new(base_address: usize) -> Self {
+    pub const fn new(base_address: usize) -> Self {
         Self {
-            reg: cast!(base_address),
+            reg_pointer: base_address as _,
         }
+    }
+
+    pub fn reg(&self) -> &mut Registers {
+        unsafe { &mut *self.reg_pointer }
     }
 
     /// Set a new base_address
     pub fn set_base_address(&mut self, base_address: usize) {
-        self.reg = cast!(base_address);
+        self.reg_pointer = base_address as _;
     }
 
     /// Read a byte
@@ -63,25 +67,25 @@ impl<'a> MmioUartXpsLite<'a> {
     /// Read Rx FIFO
     #[inline]
     pub fn read_rx(&self) -> u32 {
-        self.reg.rx.read()
+        self.reg().rx.read()
     }
 
     /// Write Tx FIFO
     #[inline]
     pub fn write_tx(&self, value: u32) {
-        unsafe { self.reg.tx.write(value) }
+        unsafe { self.reg().tx.write(value) }
     }
 
     /// Read Uart Lite Status Register
     #[inline]
     pub fn read_stat(&self) -> u32 {
-        self.reg.stat.read()
+        self.reg().stat.read()
     }
 
     /// Get Uart Lite Status
     #[inline]
     pub fn status(&self) -> Status {
-        Status::from_bits_truncate(self.reg.stat.read().reverse_bits() as u8)
+        Status::from_bits_truncate(self.reg().stat.read().reverse_bits() as u8)
     }
 
     pub fn is_rx_fifo_valid(&self) -> bool {
@@ -119,7 +123,7 @@ impl<'a> MmioUartXpsLite<'a> {
     /// Write Uart Lite Control Register
     #[inline]
     pub fn write_ctrl(&self, value: u32) {
-        unsafe { self.reg.ctrl.write(value) }
+        unsafe { self.reg().ctrl.write(value) }
     }
 
     pub fn enable_interrupt(&self) {
@@ -173,21 +177,25 @@ impl<'a> fmt::Write for MmioUartXpsLite<'a> {
 /// # MMIO version of AXI UART Lite
 ///
 /// **Noticed** This hasn't been tested.
-pub struct MmioUartAxiLite<'a> {
-    reg: &'a mut Registers,
+pub struct MmioUartAxiLite {
+    reg_pointer: *mut Registers,
 }
 
-impl<'a> MmioUartAxiLite<'a> {
+impl MmioUartAxiLite {
     /// New a uart
-    pub fn new(base_address: usize) -> Self {
+    pub const fn new(base_address: usize) -> Self {
         Self {
-            reg: cast!(base_address),
+            reg_pointer: base_address as _,
         }
+    }
+
+    pub fn reg(&self) -> &mut Registers {
+        unsafe { &mut *self.reg_pointer }
     }
 
     /// Set a new base_address
     pub fn set_base_address(&mut self, base_address: usize) {
-        self.reg = cast!(base_address);
+        self.reg_pointer = base_address as _;
     }
 
     /// Read a byte
@@ -204,28 +212,55 @@ impl<'a> MmioUartAxiLite<'a> {
         self.write_tx(value as u32)
     }
 
+    /// Read a slice
+    pub fn read(&self, buf: &mut [u8]) -> usize {
+        let mut count = 0;
+        for current in buf {
+            if let Some(ch) = self.read_byte() {
+                count += 1;
+                *current = ch;
+            } else {
+                break;
+            }
+        }
+        count
+    }
+
+    /// Write a slice
+    pub fn write(&self, buf: &[u8]) -> usize {
+        let mut count = 0;
+        for current in buf {
+            if self.is_tx_fifo_full() {
+                break;
+            }
+            count += 1;
+            self.write_byte(*current);
+        }
+        count
+    }
+
     /// Read Rx FIFO
     #[inline]
     pub fn read_rx(&self) -> u32 {
-        self.reg.rx.read()
+        self.reg().rx.read()
     }
 
     /// Write Tx FIFO
     #[inline]
     pub fn write_tx(&self, value: u32) {
-        unsafe { self.reg.tx.write(value) }
+        unsafe { self.reg().tx.write(value) }
     }
 
     /// Read Uart Lite Status Register
     #[inline]
     pub fn read_stat(&self) -> u32 {
-        self.reg.stat.read()
+        self.reg().stat.read()
     }
 
     /// Get Uart Lite Status
     #[inline]
     pub fn status(&self) -> Status {
-        Status::from_bits_truncate(self.reg.stat.read() as u8)
+        Status::from_bits_truncate(self.reg().stat.read() as u8)
     }
 
     pub fn is_rx_fifo_valid(&self) -> bool {
@@ -263,7 +298,7 @@ impl<'a> MmioUartAxiLite<'a> {
     /// Write Uart Lite Control Register
     #[inline]
     pub fn write_ctrl(&self, value: u32) {
-        unsafe { self.reg.ctrl.write(value) }
+        unsafe { self.reg().ctrl.write(value) }
     }
 
     pub fn enable_interrupt(&self) {


### PR DESCRIPTION
本 PR 提供以下修改：

- 考虑传入的应只为地址，保留 lifetime 应并无必要。修改后结构体中只保留地址，并在需要的时候解引用。
- 为 `MmioUartAxiLite` 增加了 `read()` 和 `write()` 函数用于直接读取/写入一个 slice。
- 更新了部分依赖。

---

This pull request implements the following features.

- We should only pass the address into the struct, so I think it’s meaningless to keep a reference and manage a lifetime. After the changes, we only store the address and dereference it when needed.
- Add `read()` and `write()` functions for `MmioUartAxiLite` to directly read / write from a slice.
- Bump dependencies.